### PR TITLE
[FIX] Duplicate VATID output in legal.html removed

### DIFF
--- a/src/app/design/frontend/base/default/template/magesetup/imprint/legal.phtml
+++ b/src/app/design/frontend/base/default/template/magesetup/imprint/legal.phtml
@@ -40,9 +40,6 @@
 <?php if (strlen(trim($this->getContentResponsablePressLaw()))): ?>
 <?php echo $this->__('Responsible in the interests of the press law') ?>: <?php echo $this->getContentResponsablePressLaw() ?><br />
 <?php endif ?>
-<?php if (strlen(trim($this->getVatId()))): ?>
-    <?php echo $this->__('VAT-ID') ?>: <?php echo $this->getVatId() ?><br />
-<?php endif ?>
 <?php if (strlen(trim($this->getCourt()))): ?>
     <?php echo $this->__('Register court') ?>: <?php echo $this->getCourt() ?><br />
 <?php endif ?>


### PR DESCRIPTION
it's already present in tax.phtml and doesn't need a second output
