### PR TITLE
Options are displayed in top cart only fixed.

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Helper/Catalog/Product/Configuration.php
+++ b/src/app/code/community/FireGento/MageSetup/Helper/Catalog/Product/Configuration.php
@@ -86,15 +86,12 @@ class FireGento_MageSetup_Helper_Catalog_Product_Configuration
     {
         $itemId = $item->getId();
         if (!isset($this->_finished[$itemId])) {
-            $this->_finished[$itemId] = true;
             $product    = $this->_getProduct($item);
             $attributes = $this->_getAdditionalData($product);
-            if (count($attributes) > 0) {
-                return $attributes;
-            }
+            $this->_finished[$itemId] = $attributes;
         }
 
-        return array();
+        return $this->_finished[$itemId];
     }
 
     /**


### PR DESCRIPTION
Many themes have top cart with items dropdown, so on the shopping cart page 
the method will be called for top and bottom carts. But bottom cart will receive 
empty array instead of attributes.
