### PR TITLE
Add missing formkey for multishipping order confirmation page

### DIFF
--- a/src/app/design/frontend/base/default/template/magesetup/checkout/multishipping/overview.phtml
+++ b/src/app/design/frontend/base/default/template/magesetup/checkout/multishipping/overview.phtml
@@ -28,6 +28,7 @@
     </div>
     <?php echo $this->getMessagesBlock()->getGroupedHtml() ?>
     <form action="<?php echo $this->getPostActionUrl() ?>" method="post" onsubmit="return showLoader();">
+        <?php echo $this->getBlockHtml('formkey'); ?>
         <?php echo $this->getChildHtml('agreements') ?>
 
         <div class="col2-set">


### PR DESCRIPTION
Multishipping does not work with Magento 1.8, because there is a form key missing.
