### PR TITLE
fixed js_template default config

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/etc/config.xml
+++ b/src/app/code/community/FireGento/MageSetup/etc/config.xml
@@ -336,12 +336,7 @@ Tel: {{var telephone}}
 {{depend telephone}}Tel: {{var telephone}}{{/depend}}|
 {{depend fax}}<br/>Fax: {{var fax}}{{/depend}}|
                 ]]></pdf>
-                <js_template template="title" module="customer">
-                    <title>Javascript Template</title>
-                    <defaultFormat>
-                        <![CDATA[#{company}<br/>#{prefix} #{firstname} #{middlename} #{lastname} #{suffix}<br/>#{street0}<br/>#{street1}<br/>#{street2}<br/>#{street3}<br/>#{postcode} #{city}<br/>#{country_id}<br/>Tel: #{telephone}<br/>Fax: #{fax}]]>
-                    </defaultFormat>
-                </js_template>
+                <js_template><![CDATA[#{company}<br/>#{prefix} #{firstname} #{middlename} #{lastname} #{suffix}<br/>#{street0}<br/>#{street1}<br/>#{street2}<br/>#{street3}<br/>#{postcode} #{city}<br/>#{country_id}<br/>Tel: #{telephone}<br/>Fax: #{fax}]]></js_template>
             </address_templates>
         </customer>
 


### PR DESCRIPTION
etc/config.xml defines a wrong format for `default/customer/address_templates/js_template`. Magento expects a string value, no child nodes. This results in an array-to-string conversion notice in various places.
