### PR TITLE
Add version checking for the b2b professional extension

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Block/Bundle/Catalog/Product/Price/Abstract.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Bundle/Catalog/Product/Price/Abstract.php
@@ -30,7 +30,10 @@
  */
 
 // @codingStandardsIgnoreStart
-if (Mage::getConfig()->getModuleConfig('Sitewards_B2BProfessional')->is('active', 'true')) {
+if (
+    Mage::getConfig()->getModuleConfig('Sitewards_B2BProfessional')->is('active', 'true')
+    && version_compare (Mage::getConfig()->getModuleConfig('Sitewards_B2BProfessional')->version, '2.1.0', '<=' )
+) {
 
     abstract class FireGento_MageSetup_Block_Bundle_Catalog_Product_Price_Abstract
         extends Sitewards_B2BProfessional_Block_Price


### PR DESCRIPTION
I have added the same version checking that is in the FireGento_MageSetup_Block_Catalog_Product_Price_Abstract into FireGento_MageSetup_Block_Bundle_Catalog_Product_Price_Abstract as this was causing issues with bundle products with newer versions of the b2b professional extension
