### PR TITLE
Update overview.phtml

### DIFF
--- a/src/app/design/frontend/base/default/template/magesetup/checkout/multishipping/overview.phtml
+++ b/src/app/design/frontend/base/default/template/magesetup/checkout/multishipping/overview.phtml
@@ -27,7 +27,8 @@
         <h1><?php echo $this->__('Review Order') ?></h1>
     </div>
     <?php echo $this->getMessagesBlock()->getGroupedHtml() ?>
-    <form action="<?php echo $this->getPostActionUrl() ?>" method="post" onsubmit="return showLoader();">
+    <form id="review-order-form" action="<?php echo $this->getPostActionUrl() ?>" method="post" onsubmit="return showLoader();">
+        <?php echo $this->getBlockHtml('formkey'); ?>
         <?php echo $this->getChildHtml('agreements') ?>
 
         <div class="col2-set">


### PR DESCRIPTION
[BUGFIX] Multiple address shipping bug which prevents the order from completion - the user is redirected to the first step instead of to the order confirmation step

Solved by adding <?php echo $this->getBlockHtml('formkey'); ?> on line 31 and id="review-order-form" to line 30
