### PR TITLE
[TASK] Remove Invalid Shipping Tax Calculation Algo

### DIFF
--- a/docs/api/html/classes/FireGento_MageSetup_Model_Tax_Config.xhtml
+++ b/docs/api/html/classes/FireGento_MageSetup_Model_Tax_Config.xhtml
@@ -26,7 +26,7 @@
             <a href="#XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX">XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX</a>
           </li>
           <li>
-            <a href="#USE_HIGHTES_TAX_ON_PRODUCTS">USE_HIGHTES_TAX_ON_PRODUCTS</a>
+            <a href="#USE_HIGHEST_TAX_ON_PRODUCTS">USE_HIGHEST_TAX_ON_PRODUCTS</a>
           </li>
           <li>
             <a href="#USE_TAX_DEPENDING_ON_PRODUCT_VALUES">USE_TAX_DEPENDING_ON_PRODUCT_VALUES</a>
@@ -53,7 +53,7 @@
         <h3>Constants</h3>
         <ul class="varlist">
           <li><a name="XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX"/>XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX = 'tax/classes/shipping_tax_on_product_tax'<hr/></li>
-          <li><a name="USE_HIGHTES_TAX_ON_PRODUCTS"/>USE_HIGHTES_TAX_ON_PRODUCTS = 1<hr/></li>
+          <li><a name="USE_HIGHEST_TAX_ON_PRODUCTS"/>USE_HIGHEST_TAX_ON_PRODUCTS = 1<hr/></li>
           <li><a name="USE_TAX_DEPENDING_ON_PRODUCT_VALUES"/>USE_TAX_DEPENDING_ON_PRODUCT_VALUES = 2<hr/></li>
         </ul>
         <h3>Methods</h3>

--- a/docs/api/xml/classes/FireGento_MageSetup_Model_Tax_Config.xml
+++ b/docs/api/xml/classes/FireGento_MageSetup_Model_Tax_Config.xml
@@ -9,7 +9,7 @@
   </docblock>
   <extends full="Mage_Tax_Model_Config" namespace="" name="Mage_Tax_Model_Config"/>
   <constant name="XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX" value="'tax/classes/shipping_tax_on_product_tax'"/>
-  <constant name="USE_HIGHTES_TAX_ON_PRODUCTS" value="1"/>
+  <constant name="USE_HIGHEST_TAX_ON_PRODUCTS" value="1"/>
   <constant name="USE_TAX_DEPENDING_ON_PRODUCT_VALUES" value="2"/>
   <method name="getShippingTaxClass" start="43" end="124" abstract="false" final="false" static="false" visibility="public">
     <docblock>

--- a/src/app/code/community/FireGento/MageSetup/Block/Adminhtml/Notifications.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Adminhtml/Notifications.php
@@ -34,6 +34,7 @@ class FireGento_MageSetup_Block_Adminhtml_Notifications extends Mage_Adminhtml_B
      */
     protected function _construct()
     {
+        parent::_construct();
         $this->addData(array('cache_lifetime'=> null));
     }
 

--- a/src/app/code/community/FireGento/MageSetup/Block/Adminhtml/Notifications.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Adminhtml/Notifications.php
@@ -48,6 +48,19 @@ class FireGento_MageSetup_Block_Adminhtml_Notifications extends Mage_Adminhtml_B
     }
 
     /**
+     * Returns a value that indicates if the shipping tax config is wrong.
+     *
+     * @return bool Flag if Shipping Tax Config is wrong
+     */
+    public function isWrongShippingTaxConfig()
+    {
+        if(Mage::getModel('magesetup/shippingtax_flag')->loadSelf()->getFlagData() == 'wrong'){
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Get magesetup management url
      *
      * @return string URL for MageSetup form

--- a/src/app/code/community/FireGento/MageSetup/Model/Observer.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Observer.php
@@ -296,26 +296,6 @@ class FireGento_MageSetup_Model_Observer
     }
 
     /**
-     * After updating the quantities of cart items, it might be needed to recalculate the shipping tax
-     *
-     * Event: <checkout_cart_update_items_after>
-     *
-     * @param Varien_Event_Observer $observer Observer
-     */
-    public function recollectAfterQuoteItemUpdate(Varien_Event_Observer $observer)
-    {
-        $store = Mage::app()->getStore();
-        if (Mage::getStoreConfig(FireGento_MageSetup_Model_Tax_Config::XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX, $store)
-            == FireGento_MageSetup_Model_Tax_Config::USE_TAX_DEPENDING_ON_PRODUCT_VALUES
-        ) {
-            Mage::getSingleton('checkout/session')
-                ->getQuote()
-                ->setTotalsCollectedFlag(false)
-                ->collectTotals();
-        }
-    }
-
-    /**
      * Get required agreements on custom registration
      *
      * @return array Customer agreement ids

--- a/src/app/code/community/FireGento/MageSetup/Model/Shippingtax/Flag.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Shippingtax/Flag.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of a FireGento e.V. module.
+ *
+ * This FireGento e.V. module is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This script is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * PHP version 5
+ *
+ * @category  FireGento
+ * @package   FireGento_MageSetup
+ * @author    FireGento Team <team@firegento.com>
+ * @copyright 2014 FireGento Team (http://www.firegento.com)
+ * @license   http://opensource.org/licenses/gpl-3.0 GNU General Public License, version 3 (GPLv3)
+ * @since     0.2.0
+ */
+/**
+ * Flag class
+ *
+ * @category FireGento
+ * @package  FireGento_MageSetup
+ * @author   FireGento Team <team@firegento.com>
+ */
+
+class FireGento_MageSetup_Model_Shippingtax_Flag extends Mage_Core_Model_Flag {
+
+    /**
+     * Flag code
+     *
+     * @var string
+     */
+    protected $_flagCode = 'magesetup_shipping_tax_config';
+
+}

--- a/src/app/code/community/FireGento/MageSetup/Model/Source/Tax/DynamicType.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Source/Tax/DynamicType.php
@@ -46,10 +46,6 @@ class FireGento_MageSetup_Model_Source_Tax_DynamicType
                 'value' => FireGento_MageSetup_Model_Tax_Config::USE_HIGHTES_TAX_ON_PRODUCTS,
                 'label' => $helper->__('Use the highest product tax')
             ),
-            array(
-                'value' => FireGento_MageSetup_Model_Tax_Config::USE_TAX_DEPENDING_ON_PRODUCT_VALUES,
-                'label' => $helper->__('Use the tax rate of products that make up the biggest amount')
-            ),
         );
     }
 }

--- a/src/app/code/community/FireGento/MageSetup/Model/Source/Tax/DynamicType.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Source/Tax/DynamicType.php
@@ -43,7 +43,7 @@ class FireGento_MageSetup_Model_Source_Tax_DynamicType
                 'label' => $helper->__('No dynamic shipping tax caluclation')
             ),
             array(
-                'value' => FireGento_MageSetup_Model_Tax_Config::USE_HIGHTES_TAX_ON_PRODUCTS,
+                'value' => FireGento_MageSetup_Model_Tax_Config::USE_HIGHEST_TAX_ON_PRODUCTS,
                 'label' => $helper->__('Use the highest product tax')
             ),
         );

--- a/src/app/code/community/FireGento/MageSetup/Model/System/Config/Backend/Tax/Config.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/System/Config/Backend/Tax/Config.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of a FireGento e.V. module.
+ *
+ * This FireGento e.V. module is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This script is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * PHP version 5
+ *
+ * @category  FireGento
+ * @package   FireGento_MageSetup
+ * @author    FireGento Team <team@firegento.com>
+ * @copyright 2014 FireGento Team (http://www.firegento.com)
+ * @license   http://opensource.org/licenses/gpl-3.0 GNU General Public License, version 3 (GPLv3)
+ * @since     2.3.0
+ */
+/**
+ * Flag class
+ *
+ * @category FireGento
+ * @package  FireGento_MageSetup
+ * @author   FireGento Team <team@firegento.com>
+ */
+
+
+class FireGento_MageSetup_Model_System_Config_Backend_Tax_Config extends Mage_Core_Model_Config_Data
+{
+    protected function _afterSave()
+    {
+        // This work-around might be neccessary due to less meaningful config values in the future
+        // So we can reuse config value '2' for dynamic shipping tax calc algo without
+        // confusing it with the prior 2.2.0 version
+
+        $flag = Mage::getModel('magesetup/shippingtax_flag')->loadSelf();
+        if ($flag->getFlagData() == 'wrong') {
+            $flag->setFlagData('fixed')->save();
+        }
+        return parent::_afterSave();
+    }
+
+
+}

--- a/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
@@ -31,7 +31,6 @@ class FireGento_MageSetup_Model_Tax_Config extends Mage_Tax_Model_Config
 {
     const XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX = 'tax/classes/shipping_tax_on_product_tax';
     const USE_HIGHTES_TAX_ON_PRODUCTS = 1;
-    const USE_TAX_DEPENDING_ON_PRODUCT_VALUES = 2;
 
     /**
      * Get tax class id specified for shipping tax estimation based on highest product

--- a/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
@@ -80,37 +80,16 @@ class FireGento_MageSetup_Model_Tax_Config extends Mage_Tax_Model_Config
                 continue;
             }
 
-            if (Mage::getStoreConfig(self::XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX, $store)
-                == self::USE_TAX_DEPENDING_ON_PRODUCT_VALUES
-            ) {
-                // sum up all product values grouped by the tax class id
-                if (isset($taxClassSums[$item->getTaxClassId()])) {
-                    $taxClassSums[$item->getTaxClassId()] += $item->getPriceInclTax() * $item->getQty();
-                } else {
-                    $taxClassSums[$item->getTaxClassId()] = $item->getPriceInclTax() * $item->getQty();
-                }
-            } else {
-                $taxPercent = $this->_loadTaxCalculationRate($item);
-                if (is_float($taxPercent) && !in_array($taxPercent, $taxClassIds)) {
-                    $taxClassIds[$taxPercent] = $item->getTaxClassId();
-                }
+            $taxPercent = $this->_loadTaxCalculationRate($item);
+            if (is_float($taxPercent) && !in_array($taxPercent, $taxClassIds)) {
+                $taxClassIds[$taxPercent] = $item->getTaxClassId();
             }
         }
 
-        if (Mage::getStoreConfig(self::XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX, $store)
-            == self::USE_TAX_DEPENDING_ON_PRODUCT_VALUES
-        ) {
-            // get the highest value of the sums and set the taxClass
-            arsort($taxClassSums);
-            if (count($taxClassSums)) {
-                $highestTaxRate = key($taxClassSums);
-            }
-        } else {
-            // Get the highest tax rate
-            ksort($taxClassIds);
-            if (count($taxClassIds)) {
-                $highestTaxRate = array_pop($taxClassIds);
-            }
+        // Get the highest tax rate
+        ksort($taxClassIds);
+        if (count($taxClassIds)) {
+            $highestTaxRate = array_pop($taxClassIds);
         }
 
         if (!$highestTaxRate || is_null($highestTaxRate)) {

--- a/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
@@ -30,7 +30,7 @@
 class FireGento_MageSetup_Model_Tax_Config extends Mage_Tax_Model_Config
 {
     const XML_PATH_SHIPPING_TAX_ON_PRODUCT_TAX = 'tax/classes/shipping_tax_on_product_tax';
-    const USE_HIGHTES_TAX_ON_PRODUCTS = 1;
+    const USE_HIGHEST_TAX_ON_PRODUCTS = 1;
 
     /**
      * Get tax class id specified for shipping tax estimation based on highest product

--- a/src/app/code/community/FireGento/MageSetup/Test/Config/Main.php
+++ b/src/app/code/community/FireGento/MageSetup/Test/Config/Main.php
@@ -160,12 +160,6 @@ class FireGento_MageSetup_Test_Config_Main extends EcomDev_PHPUnit_Test_Case_Con
         );
         $this->assertEventObserverDefined(
             'frontend',
-            'checkout_cart_update_items_after',
-            'magesetup/observer',
-            'recollectAfterQuoteItemUpdate'
-        );
-        $this->assertEventObserverDefined(
-            'frontend',
             'controller_action_predispatch_customer_account_createpost',
             'magesetup/observer',
             'customerCreatePreDispatch'

--- a/src/app/code/community/FireGento/MageSetup/Test/Model/Source/Tax/DynamicType/expectations/testToOptionArray.yaml
+++ b/src/app/code/community/FireGento/MageSetup/Test/Model/Source/Tax/DynamicType/expectations/testToOptionArray.yaml
@@ -5,6 +5,3 @@ result:
   -
     value: 1
     label: "Use the highest product tax"
-  -
-    value: 2
-    label: "Use the tax rate of products that make up the biggest amount"

--- a/src/app/code/community/FireGento/MageSetup/etc/config.xml
+++ b/src/app/code/community/FireGento/MageSetup/etc/config.xml
@@ -219,6 +219,14 @@
                     </magesetup_observer_agreement>
                 </observers>
             </adminhtml_block_html_before>
+            <admin_session_user_login_success>
+                <observers>
+                    <firegento_magesetup>
+                        <class>magesetup/observer</class>
+                        <method>checkForInvalidShippingTaxCalculationAlgo</method>
+                    </firegento_magesetup>
+                </observers>
+            </admin_session_user_login_success>
         </events>
     </adminhtml>
     <admin>

--- a/src/app/code/community/FireGento/MageSetup/etc/config.xml
+++ b/src/app/code/community/FireGento/MageSetup/etc/config.xml
@@ -145,15 +145,6 @@
                     </magesetup_observer>
                 </observers>
             </core_block_abstract_to_html_before>
-            <checkout_cart_update_items_after>
-                <observers>
-                    <recalculate_dynamic_shipping_tax>
-                        <class>magesetup/observer</class>
-                        <type>singleton</type>
-                        <method>recollectAfterQuoteItemUpdate</method>
-                    </recalculate_dynamic_shipping_tax>
-                </observers>
-            </checkout_cart_update_items_after>
             <controller_action_predispatch_customer_account_createpost>
                 <observers>
                     <magesetup_observer>

--- a/src/app/code/community/FireGento/MageSetup/etc/system.xml
+++ b/src/app/code/community/FireGento/MageSetup/etc/system.xml
@@ -471,7 +471,7 @@
                         <shipping_tax_on_product_tax translate="label,comment" module="magesetup">
                             <label>Dynamic Shipping Tax Class Calculation</label>
                             <comment>
-                                <![CDATA[Set to "yes" if you want to calculate the shipping tax rate based on the highest product tax rate or according to the tax rate of products that make up the biggest amount in cart.<br /><b>ATTENTION:</b> This setting overwrites the "Tax Class for Shipping" setting above!]]></comment>
+                                <![CDATA[<b>ATTENTION:</b> This setting overwrites the "Tax Class for Shipping" setting above!]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>magesetup/source_tax_dynamicType</source_model>
                             <sort_order>11</sort_order>

--- a/src/app/code/community/FireGento/MageSetup/etc/system.xml
+++ b/src/app/code/community/FireGento/MageSetup/etc/system.xml
@@ -473,6 +473,7 @@
                             <comment>
                                 <![CDATA[<b>ATTENTION:</b> This setting overwrites the "Tax Class for Shipping" setting above!]]></comment>
                             <frontend_type>select</frontend_type>
+                            <backend_model>magesetup/system_config_backend_tax_config</backend_model>
                             <source_model>magesetup/source_tax_dynamicType</source_model>
                             <sort_order>11</sort_order>
                             <show_in_default>1</show_in_default>

--- a/src/app/design/adminhtml/default/default/template/magesetup/notifications.phtml
+++ b/src/app/design/adminhtml/default/default/template/magesetup/notifications.phtml
@@ -31,3 +31,11 @@
         <?php echo $this->helper('magesetup')->__('Click <a href="%s">here</a> to set up your pages, blocks, emails and tax settings.', $this->getManageUrl()) ?>
     </div>
 <?php endif ?>
+<?php if ($this->isWrongShippingTaxConfig()): ?>
+    <div class="notification-global">
+        <span class="span.critical">
+            <strong><?php echo $this->helper('magesetup')->__('Shipping Tax Configuration:') ?></strong>
+            <?php echo $this->helper('magesetup')->__('Please check your dynamic shipping tax configuration in <a href="%s">system config at tax -&gt; classes!</a> You have to reconfigure it, as the current value "Use the tax rate of products that make up the biggest amount" is not valid anymore.', Mage::getModel('adminhtml/url')->getUrl('*/system_config/edit', array('section' => 'tax'))); ?>
+            </span>
+    </div>
+<?php endif ?>

--- a/src/app/locale/de_DE/FireGento_MageSetup.csv
+++ b/src/app/locale/de_DE/FireGento_MageSetup.csv
@@ -101,7 +101,7 @@
 "Ensures that the ip address of the customers doesnt get involved into the tracking", "Stellt sicher das die IP Adresse der Kunden beim Tracking nicht mit übertragen werden (Datenschutz)"
 
 "Dynamic Shipping Tax Class Calculation","Dynamische Berechnung der Versand-Steuerklasse"
-"Set to ""yes"" if you want to calculate the shipping tax rate based on the highest product tax rate in cart.<br /><b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","Auf ""Ja"" stellen, wenn Sie die Versand-Steuerklasse basierend auf der höchsten Produktsteuerklasse im Warenkorb dynamisch berechnen lassen möchten.<br /><b>ACHTUNG:</b> Diese Einstellung überschreibt die Einstellung ""Steuerklasse für den Versand"" darüber."
+"<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","<b>ACHTUNG:</b> Diese Einstellung überschreibt die Einstellung ""Steuerklasse für den Versand"" darüber."
 
 "Shipping from","Versand aus"
 "This setting is base for the tax rate setup!","Diese Einstellung wird für das Setup der Steuereinstellungen verwendet!"

--- a/src/app/locale/de_DE/FireGento_MageSetup.csv
+++ b/src/app/locale/de_DE/FireGento_MageSetup.csv
@@ -98,10 +98,12 @@
 "Recommended Extensions","Empfohlene Erweiterungen"
 "Popular Payment Methods","Beliebte Zahlungsmethoden"
 "Ip anonymization", "IP Adresse verschleiern"
-"Ensures that the ip address of the customers doesnt get involved into the tracking", "Stellt sicher das die IP Adresse der Kunden beim Tracking nicht mit übertragen werden (Datenschutz)"
+"Ensures that the ip address of the customers doesnt get involved into the tracking", "Stellt sicher, dass die IP Adresse der Kunden beim Tracking nicht mit übertragen werden (Datenschutz)"
 
 "Dynamic Shipping Tax Class Calculation","Dynamische Berechnung der Versand-Steuerklasse"
 "<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","<b>ACHTUNG:</b> Diese Einstellung überschreibt die Einstellung ""Steuerklasse für den Versand"" darüber."
+"Please check your dynamic shipping tax configuration in <a href=""%s"">system config at tax -&gt; classes!</a> You have to reconfigure it, as the current value ""Use the tax rate of products that make up the biggest amount"" is not valid anymore.","Bitte prüfen Sie Ihre Einstellungen zur dymischen Versandsteuerberechnung in der <a href=""%s"">Systemkonfiguration unter Steuern -&gt; Steuerklassen!</a> Sie müssen die Einstellungen ändern, da der bisherige Wert ""Use the tax rate of products that make up the biggest amount"" nicht länger gültig ist."
+"Shipping Tax Configuration:","Versandsteuer-Konfiguration:"
 
 "Shipping from","Versand aus"
 "This setting is base for the tax rate setup!","Diese Einstellung wird für das Setup der Steuereinstellungen verwendet!"

--- a/src/app/locale/en_US/FireGento_MageSetup.csv
+++ b/src/app/locale/en_US/FireGento_MageSetup.csv
@@ -103,7 +103,7 @@
 "Ensures that the ip address of the customers doesnt get involved into the tracking","Ensures that the ip address of the customers doesnt get involved into the tracking"
 
 "Dynamic Shipping Tax Class Calculation","Dynamic Shipping Tax Class Calculation"
-"Set to ""yes"" if you want to calculate the shipping tax rate based on the highest product tax rate in cart.<br /><b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","Set to ""yes"" if you want to calculate the shipping tax rate based on the highest product tax rate in cart.<br /><b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!"
+"<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!"
 
 "Shipping from","Shipping from"
 "This setting is base for the tax rate setup!","This setting is base for the tax rate setup!"

--- a/src/app/locale/fr_FR/FireGento_MageSetup.csv
+++ b/src/app/locale/fr_FR/FireGento_MageSetup.csv
@@ -95,7 +95,7 @@
 "Ensures that the ip address of the customers doesnt get involved into the tracking","Il assure que l'adresse IP du client ne va pas être transmettre au tracker (protection des donn?es)"
 
 "Dynamic Shipping Tax Class Calculation","Calculation dynamique de la classe de taxe livraison"
-"Set to ""yes"" if you want to calculate the shipping tax rate based on the highest product tax rate in cart.<br /><b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!", "Sélectionnez ""Oui"" si vous souhaitez calculer le taux de la taxe de livraison basé sur le plus haut taux de taxe produit du panier.<br /><b>ATTENTION:</b> ce réglage écrase le réglage ""Classe de taxe de livraison"" ci-dessus!"
+"<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!", "<b>ATTENTION:</b> ce réglage écrase le réglage ""Classe de taxe de livraison"" ci-dessus!"
 
 "Shipping from","Livraison depuis"
 "This setting is base for the tax rate setup!","Ce réglage est la base pour le réglage du taux de la taxe!"

--- a/src/app/locale/it_IT/FireGento_MageSetup.csv
+++ b/src/app/locale/it_IT/FireGento_MageSetup.csv
@@ -98,7 +98,7 @@
 "Ensures that the ip address of the customers doesnt get involved into the tracking","Assicura che l'IP del cliente non venga coinvolto nel tracciamento"
 
 "Dynamic Shipping Tax Class Calculation","Calcolo dinamico della classe fiscale delle spedizioni"
-"Set to ""yes"" if you want to calculate the shipping tax rate based on the highest product tax rate in cart.<br /><b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","Imposta su ""si"" se vuoi calcolare la tassazione delle spedizioni sulla base della tassazione più altra tra i prodotti presenti nel carrello.<br /><b>ATTENZIONE:</b> Questa impostazione sovrascrive la configurazione ""Classe fiscale per le spedizioni"" di cui sopra!"
+"<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","<b>ATTENZIONE:</b> Questa impostazione sovrascrive la configurazione ""Classe fiscale per le spedizioni"" di cui sopra!"
 
 "Shipping from","Spedito da"
 "This setting is base for the tax rate setup!","Questo settaggio è utilizzato per la configurazione delle tasse!"

--- a/src/app/locale/nl_NL/FireGento_MageSetup.csv
+++ b/src/app/locale/nl_NL/FireGento_MageSetup.csv
@@ -102,7 +102,7 @@
 "Ensures that the ip address of the customers doesnt get involved into the tracking","Zorgt ervoor dat het ip adres van de klanten niet meegenomen worden in de tracking"
 
 "Dynamic Shipping Tax Class Calculation","Dynamische verzendkosten BTW groep berekening"
-"Set to ""yes"" if you want to calculate the shipping tax rate based on the highest product tax rate in cart.<br /><b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","Zet op ""ja"" als je wilt dat de verzendkosten BTW op basis van het hoogste BTW product in winkelwagen wordt berekend <br /> <b>. LET OP: </ b> Deze instelling overschrijft de ""BTW groep voor verzendingen"" instelling hierboven!"
+"<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","<b>LET OP:</b> Deze instelling overschrijft de ""BTW groep voor verzendingen"" instelling hierboven!"
 
 "Shipping from","Verzending van"
 "This setting is base for the tax rate setup!","Deze instelling is de basis voor de BTW setup!"

--- a/src/app/locale/ru_RU/FireGento_MageSetup.csv
+++ b/src/app/locale/ru_RU/FireGento_MageSetup.csv
@@ -80,7 +80,7 @@
 "Ensures that the ip address of the customers doesnt get involved into the tracking","Гарантирует, что IP адреса клиентов не отслеживаются"
 
 "Dynamic Shipping Tax Class Calculation","Динамические вычисление налогового класса доставки"
-"Set to ""yes"" if you want to calculate the shipping tax rate based on the highest product tax rate in cart.<br /><b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","Установите ""да"" для расчёта налоговой ставки на доставку, основанной на наибольшей налоговой ставке товара в корзине.<br /><b>ВНИМАНИЕ:</b> Эта настройка заменяет настройку ""Налоговый класс на доставку"", расположенную выше!"
+"<b>ATTENTION:</b> This setting overwrites the ""Tax Class for Shipping"" setting above!","<b>ВНИМАНИЕ:</b> Эта настройка заменяет настройку ""Налоговый класс на доставку"", расположенную выше!"
 
 "Germany","Германия"
 "Austria","Австрия"


### PR DESCRIPTION
The 2nd option "Use Tax Depending on Product Values" did a wrong calculation so I removed it for now. To make that visible to old users I created a flag to store if the old config is still wrong or has been fixed (might be necessary for future upgrade where the old config value '2' is used again) and display one message after login plus a static notification. I also fixed a typo and a bug.