### PR TITLE
Removed direct config access for isIncludingTax()

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
@@ -167,7 +167,8 @@ class FireGento_MageSetup_Block_Catalog_Product_Price
     public function isIncludingTax()
     {
         if (!$this->getData('is_including_tax')) {
-            $this->setData('is_including_tax', Mage::getStoreConfig('tax/display/type'));
+            $includesTax = Mage::helper('tax')->priceIncludesTax();
+            $this->setData('is_including_tax', $includesTax);
         }
 
         return $this->getData('is_including_tax');


### PR DESCRIPTION
I programmed a module which relies on the Magento standard which is the tax helper being used for this check. The module allows customer tax group specific settings, thus a direct access to the config here instead of using the helper leads to a wrong display of the price inclusion for certain customers.