### PR TITLE
Use the email field in a more flexible way

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Block/Imprint/Field.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Imprint/Field.php
@@ -37,7 +37,7 @@ class FireGento_MageSetup_Block_Imprint_Field extends FireGento_MageSetup_Block_
      */
     protected function _toHtml()
     {
-        if ($this->getValue() == 'email') {
+        if ($this->getValue() == 'email' && !(bool) $this->getData('antispam')) {
             return $this->getEmail(true);
         }
 


### PR DESCRIPTION
Sometimes I want to output the content of the email field directly, without the antispam tags and javascript around. I haven't found any other way to do this, so here is my approach. Please feel free to correct me if I'm in the wrong here.

##### Usage
```
{{block type="magesetup/imprint_field" value="email" antispam="false"}}
OR
{{block type="magesetup/imprint_field" value="email" antispam="0"}}
OR
{{block type="magesetup/imprint_field" value="email" antispam=""}}
```

As long as the antispam parameter contains a falsy value it should do the trick. In any other case the output remains as is.