### PR TITLE
adding setProduct() for accessing it in price_info.phtml

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
@@ -76,6 +76,7 @@ class FireGento_MageSetup_Block_Catalog_Product_Price
             $htmlObject->setParentHtml($html);
             $htmlTemplate = $this->getLayout()->createBlock('core/template')
                 ->setTemplate('magesetup/price_info.phtml')
+                ->setProduct($this->getProduct())
                 ->setFormattedTaxRate($this->getFormattedTaxRate())
                 ->setIsIncludingTax($this->isIncludingTax())
                 ->setIsIncludingShippingCosts($this->isIncludingShippingCosts())


### PR DESCRIPTION
I need the product-model in price_info.phtml to access some data for deciding if shipping-costs should be displayed or if the product has free-shipping. Maybe useful for other if the need to access $product...