### PR TITLE
Set "Added At" Date For Mail Templates

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Model/Setup/Email.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Setup/Email.php
@@ -107,6 +107,7 @@ class FireGento_MageSetup_Model_Setup_Email extends FireGento_MageSetup_Model_Se
             $template
                 ->setTemplateCode($templateCode)
                 ->setTemplateType($emailData['template_type'])
+                ->setAddedAt(Mage::getSingleton('core/date')->gmtDate())
                 ->setModifiedAt(Mage::getSingleton('core/date')->gmtDate());
 
             // Filter areas from template file


### PR DESCRIPTION
Without the fix, the "added at" column of the transactional mail templates shows an empty cell. This PR fixes this issue.