### PR TITLE
strip_tags for meta_description

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Model/Observer.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Observer.php
@@ -139,6 +139,7 @@ class FireGento_MageSetup_Model_Observer
             if (empty($description)) {
                 $description = $keywords;
             }
+            $description = strip_tags($description);
             if (mb_strlen($description) > 255) {
                 $remainder = '';
                 $description = Mage::helper('core/string')->truncate($description, 255, '...', $remainder, false);


### PR DESCRIPTION
Added a strip_tags to prevent including html-Tags in meta_description. Removal of markup-overhead allows more usefull information in the 255 chars