### PR TITLE
Added grouped to list of types without explicit product tax class.

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
@@ -153,6 +153,7 @@ class FireGento_MageSetup_Block_Catalog_Product_Price
     {
         if ($this->getTaxRate() === null
             || $this->getProduct()->getTypeId() == 'bundle'
+            || $this->getProduct()->getTypeId() == 'grouped'
         ) {
             return '';
         }


### PR DESCRIPTION
Grouped product have no tax_class_id. I'm not sure if it would be better to check if product `isComposite` instead of a list of product types.