### PR TITLE
use magesetup specific agreements in paypal express checkout

### DIFF
--- a/src/app/design/frontend/base/default/layout/magesetup.xml
+++ b/src/app/design/frontend/base/default/layout/magesetup.xml
@@ -523,6 +523,11 @@
     </checkout_onepage_review>
 
     <paypal_express_review>
+        <reference name="paypal.express.review">
+            <remove name="agreements" />
+            <block type="magesetup/checkout_agreements" name="magesetup.checkout.agreements" as="agreements"
+                   template="magesetup/checkout/onepage/agreements.phtml" after="details" />
+        </reference>
         <reference name="paypal.express.review.details">
             <action method="addItemRender"><type>default</type><block>checkout/cart_item_renderer</block><template>magesetup/checkout/onepage/review/item.phtml</template></action>
             <action method="addItemRender"><type>grouped</type><block>checkout/cart_item_renderer_grouped</block><template>magesetup/checkout/onepage/review/item.phtml</template></action>


### PR DESCRIPTION
MageSetup uses product revocation type specific agreements.
To display only those revocation texts which are necessary a magesetup specific block has to be used in checkout instead of the original one.
Currently in paypal express checkout it doesn't work (too much agreement texts are shown).
This patch fixes this problem.

Tested in Magento CE 1.9.1.0.