### PR TITLE
double protocoll in email imprint footer fixed

### DIFF
--- a/src/app/design/frontend/base/default/template/magesetup/imprint/email_footer.phtml
+++ b/src/app/design/frontend/base/default/template/magesetup/imprint/email_footer.phtml
@@ -45,7 +45,7 @@
         <?php echo $this->__('Fax') ?>: <?php echo $this->getFax() ?><br />
     <?php endif ?>
     <?php if (strlen(trim($this->getWeb()))): ?>
-        <?php echo $this->__('Web') ?>: <a href="http://<?php echo $this->getWeb() ?>" title="<?php echo $this->getCompanyFirst() ?>"><?php echo $this->getWeb() ?></a><br />
+        <?php echo $this->__('Web') ?>: <a href="<?php echo $this->getWeb() ?>" title="<?php echo $this->getCompanyFirst() ?>"><?php echo $this->getWeb() ?></a><br />
     <?php endif ?>
     <?php echo $this->__('E-Mail') ?>: <?php echo $this->getEmail(false) ?>
 </p>


### PR DESCRIPTION
`FireGento_MageSetup_Block_Imprint_Content::getWeb` always returns an url with the protocoll.
So there is no need to write the protocoll hard in the `magesetup/imprint/email_footer.phtml` template into the href.

At the moment the url in the mail footer looks like `http://https://www.github.com`.
After this fix the url looks like `https://www.github.com`.