### PR TITLE
switch to local composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
 
@@ -22,10 +21,10 @@ matrix:
 
 before_install:
   - mkdir test/
-  - curl -sS https://getcomposer.org/installer | php
-  - chmod +x ./composer.phar
-  - ./composer.phar --version
-  - ./composer.phar install --dev
+  - travis_retry composer self-update
+
+install:
+  - travis_retry composer install --prefer-source --no-interaction --ignore-platform-reqs
 
 before_script:
   - CURR_DIR=$(pwd)


### PR DESCRIPTION
this should re-elevate the build problems I saw reported.

> Installing dependencies (including require-dev)
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.
The build has been terminated

also fixes this problem:

> Warning: This development build of composer is over 30 days old. It is recommended to update it by running "/home/travis/.phpenv/versions/5.3/bin/composer self-update" to get the latest version.


report for example here: https://travis-ci.org/firegento/firegento-magesetup/jobs/72250423