### PR TITLE
Fixed Web Link in Email Footer

### DIFF
--- a/src/app/design/frontend/base/default/template/magesetup/imprint/email_footer.phtml
+++ b/src/app/design/frontend/base/default/template/magesetup/imprint/email_footer.phtml
@@ -45,7 +45,7 @@
         <?php echo $this->__('Fax') ?>: <?php echo $this->getFax() ?><br />
     <?php endif ?>
     <?php if (strlen(trim($this->getWeb()))): ?>
-        <?php echo $this->__('Web') ?>: <a href="http://<?php echo $this->getWeb() ?>" title="<?php echo $this->getCompanyFirst() ?>"><?php echo $this->getWeb() ?></a><br />
+        <?php echo $this->__('Web') ?>: <a href="<?php echo (strpos($this->getWeb(), 'http') === 0)? $this->getWeb() : 'http://' . $this->getWeb() ?>" title="<?php echo $this->getCompanyFirst() ?>"><?php echo $this->getWeb() ?></a><br />
     <?php endif ?>
     <?php echo $this->__('E-Mail') ?>: <?php echo $this->getEmail(false) ?>
 </p>


### PR DESCRIPTION
The shop owner may write the web link with http/https into the `web` field. This currently breaks the link in the mail footer. This PR fixes this issue.