### PR TITLE
Fixed Admin Route

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/etc/config.xml
+++ b/src/app/code/community/FireGento/MageSetup/etc/config.xml
@@ -226,7 +226,7 @@
     </adminhtml>
     <admin>
         <routers>
-            <magesetup>
+            <adminhtml>
                 <use>admin</use>
                 <args>
                     <module>FireGento_MageSetup</module>
@@ -235,7 +235,7 @@
                         <FireGento_MageSetup after="Mage_Adminhtml">FireGento_MageSetup_Adminhtml</FireGento_MageSetup>
                     </modules>
                 </args>
-            </magesetup>
+            </adminhtml>
         </routers>
     </admin>
     <default>

--- a/src/app/code/community/FireGento/MageSetup/etc/config.xml
+++ b/src/app/code/community/FireGento/MageSetup/etc/config.xml
@@ -227,10 +227,7 @@
     <admin>
         <routers>
             <adminhtml>
-                <use>admin</use>
                 <args>
-                    <module>FireGento_MageSetup</module>
-                    <frontName>magesetup</frontName>
                     <modules>
                         <FireGento_MageSetup after="Mage_Adminhtml">FireGento_MageSetup_Adminhtml</FireGento_MageSetup>
                     </modules>


### PR DESCRIPTION
Currently, the System - MageSetup link leads to a 404 page. This PR fixes this issue.