### PR TITLE
Fix dynamic shipping tax calculation for bundle products

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
@@ -78,6 +78,12 @@ class FireGento_MageSetup_Model_Tax_Config extends Mage_Tax_Model_Config
 
             /** @var $item Mage_Sales_Model_Quote_Item */
             if ($item->getParentItem()) {
+                $parentProduct = $item->getParentItem()->getProduct();
+                if ($parentProduct->getTypeId() == 'bundle' && $parentProduct->getPriceType() != 0) {
+                    continue;
+                }
+            }
+            if ($item->getProduct()->getTypeId() == 'bundle' && $item->getProduct()->getPriceType() != 0) {
                 continue;
             }
 


### PR DESCRIPTION
I'm recently faced a similar issue to #186 regarding dynamic shipping tax calculation for bundle products.

I think i found a location in `FireGento_MageSetup_Model_Tax_Config` in method `getShippingTaxClass` where tax calculation misses:
```php
/* Starting from line 75 */
// Fetch the tax rates from the quote items
$taxClassSums = array();
foreach ($quoteItems as $item) {

    /** @var $item Mage_Sales_Model_Quote_Item */
    if ($item->getParentItem()) {
        continue;
    }

    /* ... */
}
```

With this statement bundled simple product are skipped and only the tax class of the bundle product is considered for calculation. This is correct for bundle products with fixed price and maybe as well for grouped products. But for bundle products with dynamic price, the tax class should also be calculated dynamically.

I made a small fix by rewriting `FireGento_MageSetup_Model_Tax_Config`'s method `getShippingTaxClass`:
```php
// Fetch the tax rates from the quote items
$taxClassSums = array();
foreach ($quoteItems as $item) {

    /** @var $item Mage_Sales_Model_Quote_Item */
    if ($item->getParentItem()) {
        $parentProduct = $item->getParentItem()->getProduct();
        if ($parentProduct->getTypeId() == 'bundle' && $parentProduct->getPriceType() != 0) {
            continue;
        }
    }
    if ($item->getProduct()->getTypeId() == 'bundle' && $item->getProduct()->getPriceType() != 0) {
        continue;
    }

    /* ... */
}
```
So it's skipping the bundle product's simples when bundle's price is fixed. If the price is dynamic, tax class is also dynamic and so the simples are taken into account.