### PR TITLE
Fix dynamic shipping tax calculation for bundles with dynamic price

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
+++ b/src/app/code/community/FireGento/MageSetup/Model/Tax/Config.php
@@ -78,6 +78,12 @@ class FireGento_MageSetup_Model_Tax_Config extends Mage_Tax_Model_Config
 
             /** @var $item Mage_Sales_Model_Quote_Item */
             if ($item->getParentItem()) {
+                $parentProduct = $item->getParentItem()->getProduct();
+                if ($parentProduct->getTypeId() == 'bundle' && $parentProduct->getPriceType() != 0) {
+                    continue;
+                }
+            }
+            if ($item->getProduct()->getTypeId() == 'bundle' && $item->getProduct()->getPriceType() == 0) {
                 continue;
             }
 


### PR DESCRIPTION
Bundled items are ignored for shipping tax calculation. This is only correct for bundles with fixed price. When a bundle has a dynamic price, the tax class is also dynamic, so all bundled items should be considered.
