### PR TITLE
Return simple product from configurable

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Helper/Catalog/Product/Configuration.php
+++ b/src/app/code/community/FireGento/MageSetup/Helper/Catalog/Product/Configuration.php
@@ -69,6 +69,9 @@ class FireGento_MageSetup_Helper_Catalog_Product_Configuration
      */
     protected function _getProduct($item)
     {
+        if ($option = $item->getOptionByCode('simple_product')) {
+            return $option->getProduct();
+        }
         return $item->getProduct();
     }
 


### PR DESCRIPTION
Return the simple product from a configurable. Otherwise attributes that differ on the simple product (e.g. delivery time) will be taken from the configurable product.