### PR TITLE
Fixed bug https://github.com/firegento/firegento-magesetup/issues/275

### DIFF
--- a/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
+++ b/src/app/code/community/FireGento/MageSetup/Block/Catalog/Product/Price.php
@@ -169,7 +169,7 @@ class FireGento_MageSetup_Block_Catalog_Product_Price extends FireGento_MageSetu
     public function isIncludingTax()
     {
         if (!$this->getData('is_including_tax')) {
-            $includesTax = Mage::helper('tax')->priceIncludesTax();
+            $includesTax = Mage::helper('tax')->getConfig()->getPriceDisplayType();
             $this->setData('is_including_tax', $includesTax);
         }
 


### PR DESCRIPTION
As pointed out in the issue, I took the wrong reference. 

This is now fixed as taking the config model and calling the appropriate method replaces the config call used before.